### PR TITLE
`standard_score` endpoint impl

### DIFF
--- a/src/dao.rs
+++ b/src/dao.rs
@@ -22,7 +22,9 @@ pub struct Agreement {
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct StandardScore(String);
+pub struct StandardScore {
+    pub score: Option<BigDecimal>,
+}
 
 impl StatusDao {
     pub async fn connect(url: String) -> sqlx::Result<Self> {
@@ -143,7 +145,7 @@ impl StatusDao {
     ) -> sqlx::Result<StandardScore> {
         let standard_score = sqlx::query_as!(
             StandardScore,
-            r#"SELECT CALC.STANDARD_SCORE($1, $2)"#,
+            r#"SELECT CALC.STANDARD_SCORE($1, $2) as score"#,
             role_id,
             node_id
         )

--- a/src/dao.rs
+++ b/src/dao.rs
@@ -20,6 +20,10 @@ pub struct Agreement {
     status: Status,
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StandardScore(String);
+
 impl StatusDao {
     pub async fn connect(url: String) -> sqlx::Result<Self> {
         log::debug!("connect to {}", url);
@@ -130,6 +134,23 @@ impl StatusDao {
         .execute(&self.pool)
         .await?;
         Ok(())
+    }
+
+    pub async fn standard_score(
+        &self,
+        role_id: &str,
+        node_id: &str,
+    ) -> sqlx::Result<StandardScore> {
+        let standard_score = sqlx::query_as!(
+            StandardScore,
+            r#"SELECT CALC.STANDARD_SCORE($1, $2)"#,
+            role_id,
+            node_id
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(standard_score)
     }
 }
 

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 
 mod provider;
 mod requestor;
+mod score;
 
 #[derive(Deserialize)]
 struct ListQuery {
@@ -13,5 +14,6 @@ struct ListQuery {
 pub fn configure(config: &mut ServiceConfig) {
     config
         .configure(provider::configure)
-        .configure(requestor::configure);
+        .configure(requestor::configure)
+        .configure(score::configure);
 }

--- a/src/rest/requestor.rs
+++ b/src/rest/requestor.rs
@@ -30,7 +30,7 @@ async fn list_agreements(
     Ok(web::Json(agreements))
 }
 
-#[post("/requestor/{node_id}/{agreement_id}")]
+#[post("/requestor/{node_id}/{agreement_id}/{peer_id}")]
 async fn update_status(
     _: web::Query<ListQuery>,
     path: web::Path<(NodeId, String, NodeId)>,

--- a/src/rest/score.rs
+++ b/src/rest/score.rs
@@ -1,0 +1,22 @@
+use crate::dao;
+use crate::rest::ListQuery;
+use actix_web::web::ServiceConfig;
+use actix_web::{get, web};
+
+#[get("/standard_score/{role_id}/{node_id}")]
+async fn standard_score(
+    _: web::Query<ListQuery>,
+    path: web::Path<(String, String)>,
+    data: web::Data<dao::StatusDao>,
+) -> actix_web::Result<web::Json<dao::StandardScore>> {
+    let (role_id, node_id) = path.into_inner();
+    let standard_score = data
+        .standard_score(&role_id, &node_id)
+        .await
+        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+    Ok(web::Json(standard_score))
+}
+
+pub fn configure(config: &mut ServiceConfig) {
+    config.service(standard_score);
+}

--- a/src/rest/score.rs
+++ b/src/rest/score.rs
@@ -2,16 +2,33 @@ use crate::dao;
 use crate::rest::ListQuery;
 use actix_web::web::ServiceConfig;
 use actix_web::{get, web};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum Role {
+    Provider,
+    Requestor,
+}
+
+impl Role {
+    #[inline]
+    fn as_db_role(&self) -> &str {
+        match self {
+            Role::Provider => "P",
+            Role::Requestor => "R",
+        }
+    }
+}
 
 #[get("/standard_score/{role_id}/{node_id}")]
 async fn standard_score(
-    _: web::Query<ListQuery>,
-    path: web::Path<(String, String)>,
     data: web::Data<dao::StatusDao>,
+    path: web::Path<(Role, String)>,
 ) -> actix_web::Result<web::Json<dao::StandardScore>> {
     let (role_id, node_id) = path.into_inner();
     let standard_score = data
-        .standard_score(&role_id, &node_id)
+        .standard_score(role_id.as_db_role(), &node_id)
         .await
         .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
     Ok(web::Json(standard_score))


### PR DESCRIPTION
New endpoint implemented.

A slightly change in naming for 
`GET /standarized_score/[requestor|provider]/node_id` - > `GET /standard_score/[requestor|provider]/node_id`. Please review.